### PR TITLE
Use default Fable.Core assertion

### DIFF
--- a/src/Mocha.fs
+++ b/src/Mocha.fs
@@ -18,9 +18,16 @@ module Test =
 [<RequireQualifiedAccess>]
 module Expect = 
     let areEqual expected actual : unit =
-        if expected = actual 
-        then Assert.AreEqual(expected, actual)
-        else failwithf "Expected %A but got %A" expected actual
+        Assert.AreEqual(expected, actual)
+
+    let notEqual expected actual : unit =
+        Assert.NotEqual(expected, actual)
+
+    let areEqualWithMsg msg expected actual : unit =
+        Assert.AreEqual(expected, actual, msg)
+
+    let notEqualWithMsg msg expected actual : unit =
+        Assert.NotEqual(expected, actual, msg)
 
     let isTrue cond = areEqual true cond 
     let isFalse cond = areEqual false cond 


### PR DESCRIPTION
The `areEqual` helper was making an equality check before the actual assertion. This shouldn't be necessary and it's also better to fail with the Fable.Core assertion because this will [include the expected and actual values in the error](https://github.com/fable-compiler/Fable/blob/de6ecf6471c36c460414c65ab430b792b85676c7/src/fable-library/Util.ts#L103-L106) so Mocha can [show the diffing](https://mochajs.org/#diffs).