### PR TITLE
Support Focused States in Mocha tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,6 @@ bundle.js
 bundle.js.map
 dist/*
 !dist/index.html
+
+#ionide
+.ionide/

--- a/src/Mocha.fs
+++ b/src/Mocha.fs
@@ -97,40 +97,71 @@ module Mocha =
     let [<Emit("it.skip($0, $1)")>] private itSkipAsync msg (f: (unit -> unit) -> unit) = jsNative
     let [<Emit("it.only($0, $1)")>] private itOnlyAsync msg (f: (unit -> unit) -> unit) = jsNative
 
-    let rec private renderBrowserTests (tests: TestCase list) (padding: int) : Html.Node list =
+    let rec isFocused (test: TestCase ) =
+        match test with
+        | SyncTest(_,_,Focused) -> true
+        | AsyncTest(_,_,Focused) -> true
+        | TestList(_,tests) ->
+            List.exists isFocused tests
+        | _ -> false
+
+    let containsFocused (tests: TestCase list) =
+        List.exists isFocused tests
+
+    let private runSyncTestInBrowser name test padding =
+        try
+            test()
+            Html.simpleDiv [ ("style",sprintf "font-size:16px; padding-left:%dpx; color:green" padding) ] (sprintf "✔ %s" name)
+        with
+        | ex ->
+            let error : Html.Node = { Tag = "pre"; Attributes = [ "style", "font-size:16px;color:red;margin:10px; padding:10px; border: 1px solid red; border-radius: 10px" ]; Content = ex.Message; Children = [] }
+            Html.div [ ] [
+                Html.simpleDiv [ ("style",sprintf "font-size:16px; padding-left:%dpx; color:red" padding) ] (sprintf "✘ %s" name)
+                error
+            ]
+    let private runAsyncTestInBrowser name test padding =
+        let id = Guid.NewGuid().ToString()
+        async {
+            do! Async.Sleep 1000
+            match! Async.Catch(test()) with
+            | Choice1Of2 () ->
+                let div = Html.findElement id
+                Html.setInnerHtml (sprintf "✔ %s" name) div
+                Html.setAttr "style" (sprintf "font-size:16px; padding-left:%dpx;color:green" padding) div
+            | Choice2Of2 err ->
+                let div = Html.findElement id
+                Html.setInnerHtml (sprintf "✘ %s" name) div
+                let error : Html.Node = { Tag = "pre"; Attributes = [ "style", "margin:10px; padding:10px; border: 1px solid red; border-radius: 10px" ]; Content = err.Message; Children = [] }
+                Html.setAttr "style" (sprintf "font-size:16px; padding-left:%dpx;color:red" padding) div
+                Html.appendChild div (Html.createNode error)
+        } |> Async.StartImmediate
+        Html.simpleDiv [ ("id", id); ("style",sprintf "font-size:16px; padding-left:%dpx;color:gray" padding) ] (sprintf "⏳ %s" name)
+    let rec private renderBrowserTests (hasFocusedTests : bool) (tests: TestCase list) (padding: int) : Html.Node list =
         tests
         |> List.map(function
-            | SyncTest (name, test, _) ->
-                try
-                    test()
-                    Html.simpleDiv [ ("style",sprintf "font-size:16px; padding-left:%dpx; color:green" padding) ] (sprintf "✔ %s" name)
-                with
-                | ex ->
-                    let error : Html.Node = { Tag = "pre"; Attributes = [ "style", "font-size:16px;color:red;margin:10px; padding:10px; border: 1px solid red; border-radius: 10px" ]; Content = ex.Message; Children = [] }
-                    Html.div [ ] [
-                        Html.simpleDiv [ ("style",sprintf "font-size:16px; padding-left:%dpx; color:red" padding) ] (sprintf "✘ %s" name)
-                        error
-                    ]
+            | SyncTest (name, test, focus) ->
+                match focus with
+                | Normal when hasFocusedTests ->
+                    Html.simpleDiv [ ("style",sprintf "font-size:16px; padding-left:%dpx; color:#B8860B" padding) ] (sprintf "🚧 skipping '%s' due to other focused tests" name)
+                | Normal ->
+                    runSyncTestInBrowser name test padding
+                | Pending ->
+                    Html.simpleDiv [ ("style",sprintf "font-size:16px; padding-left:%dpx; color:#B8860B" padding) ] (sprintf "🚧 skipping '%s' due to it being marked as pending" name)
+                | Focused ->
+                    runSyncTestInBrowser name test padding
 
-            | AsyncTest (name, test, _) ->
-                let id = Guid.NewGuid().ToString()
-                async {
-                    do! Async.Sleep 1000
-                    match! Async.Catch(test()) with
-                    | Choice1Of2 () ->
-                        let div = Html.findElement id
-                        Html.setInnerHtml (sprintf "✔ %s" name) div
-                        Html.setAttr "style" (sprintf "font-size:16px; padding-left:%dpx;color:green" padding) div
-                    | Choice2Of2 err ->
-                        let div = Html.findElement id
-                        Html.setInnerHtml (sprintf "✘ %s" name) div
-                        let error : Html.Node = { Tag = "pre"; Attributes = [ "style", "margin:10px; padding:10px; border: 1px solid red; border-radius: 10px" ]; Content = err.Message; Children = [] }
-                        Html.setAttr "style" (sprintf "font-size:16px; padding-left:%dpx;color:red" padding) div
-                        Html.appendChild div (Html.createNode error)
-                } |> Async.StartImmediate
-                Html.simpleDiv [ ("id", id); ("style",sprintf "font-size:16px; padding-left:%dpx;color:gray" padding) ] (sprintf "⏳ %s" name)
+            | AsyncTest (name, test, focus) ->
+                match focus with
+                | Normal when hasFocusedTests ->
+                    Html.simpleDiv [ ("style",sprintf "font-size:16px; padding-left:%dpx; color:#B8860B" padding) ] (sprintf "🚧 skipping '%s' due to other focused tests" name)
+                | Normal ->
+                    runAsyncTestInBrowser name test padding
+                | Pending ->
+                    Html.simpleDiv [ ("style",sprintf "font-size:16px; padding-left:%dpx; color:#B8860B" padding) ] (sprintf "🚧 skipping '%s' due to it being marked as pending" name)
+                | Focused ->
+                    runAsyncTestInBrowser name test padding
             | TestList (name, testCases) ->
-                let tests = Html.div [] (renderBrowserTests testCases (padding + 20))
+                let tests = Html.div [] (renderBrowserTests hasFocusedTests testCases (padding + 20))
                 let header : Html.Node = { Tag = "div"; Attributes = [ ("style", sprintf "font-size:20px; padding:%dpx" padding) ]; Content = name; Children = [] }
                 Html.div [ ("style", "margin-bottom:20px;") ] [ header; tests ])
 
@@ -144,7 +175,8 @@ module Mocha =
 
     let rec runTests (tests: TestCase list) =
         if Env.insideBrowser || Env.insideWorker then
-            let container = Html.div [ ("style", "padding:20px;") ] (renderBrowserTests tests 0)
+            let hasFocusedTests = containsFocused tests
+            let container = Html.div [ ("style", "padding:20px;") ] (renderBrowserTests hasFocusedTests tests 0)
             let element = Html.createNode container
             Html.appendChild Html.body element
         else

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -21,6 +21,14 @@ let mochaTests =
                 let answer = x * 2
                 Expect.areEqual 42 answer
             }
+        
+        ptestCase "skipping this one" <| fun _ ->
+            failwith "Shouldn't be running this test"
+
+        ptestCaseAsync "skipping this one async" <| fun _ ->
+            async {
+                failwith "Shouldn't be running this test"
+            }
     ]
 
 let secondModuleTests =
@@ -51,9 +59,20 @@ let nestedTestCase =
         ]
     ]
 
+let focusedTestsCases =
+    testList "Focused" [
+        ftestCase "Focused sync test" <| fun _ ->
+            Expect.areEqual (1 + 1) 2
+        ftestCaseAsync "Focused async test" <| fun _ ->
+            async {
+                Expect.areEqual (1 + 1) 2
+            }
+    ]
+
 Mocha.runTests [
     mochaTests
     secondModuleTests
     structuralEqualityTests
     nestedTestCase
+    // focusedTestsCases
 ]

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -2,6 +2,10 @@ module Tests
 
 open Fable.Mocha
 
+
+
+
+
 let mochaTests =
     testList "Mocha framework tests" [
 


### PR DESCRIPTION
This adds support for the [`FocusState`](https://github.com/haf/expecto/blob/55444f36f186840d10b6eb665ea3d92be2e66acb/Expecto/Expecto.fs#L85) concept from Expecto.  Currently only support Mocha testing. 

~To support browser tests we'll have to implement a similar flat list like [this code](https://github.com/haf/expecto/blob/55444f36f186840d10b6eb665ea3d92be2e66acb/Expecto/Expecto.fs#L321).~

~I figured I'd get the Mocha part working first then tackle the browser one possibly later.~


This now supports it in the browser tests as well. The shade of yellow I chose has an accessibility rating of 3.25 according to http://colorsafe.co/.  The emoji used is just a placeholder. 

<img width="563" alt="Screen Shot 2019-05-25 at 7 49 19 PM" src="https://user-images.githubusercontent.com/1490044/58375665-46833700-7f26-11e9-92f6-a56cd6c68100.png">
