### PR TITLE
Align expecto api 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "FSharp.fsacRuntime": "netcore"
+}

--- a/appveyor.cmd
+++ b/appveyor.cmd
@@ -1,0 +1,2 @@
+npm test
+npm run dotnet-test

--- a/appveyor.cmd
+++ b/appveyor.cmd
@@ -1,2 +1,3 @@
 npm test
-npm run dotnet-test
+REM npm run dotnet-test
+npm run dotnet-expecto

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+npm test
+npm run dotnet-test

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -4,4 +4,5 @@ set -eu
 set -o pipefail
 
 npm test
-npm run dotnet-test
+# npm run dotnet-test
+npm run dotnet-expecto

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,6 @@ install:
 os: Visual Studio 2017
 
 build_script:
-  - cmd: npm test
+  - cmd: appveyor.cmd
 
 test: off

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "build": "fable-splitter tests -o dist/tests --commonjs",
     "pretest": "fable-splitter tests -o dist/tests --commonjs",
     "test": "mocha dist/tests --timeout 5000",
-    "dotnet-test": "dotnet run -p ./tests/Tests.fsproj -- --summary",
+    "dotnet-clean": "dotnet clean ./tests/Tests.fsproj", 
+    "dotnet-test": "dotnet run -p ./tests/Tests.fsproj",
+    "dotnet-expecto": "dotnet run -p ./tests/Tests.fsproj -c EXPECTO -- --summary",
     "publish": "fable build.fsx --run clean build test publish",
     "start": "webpack-dev-server",
     "build-for-browser": "webpack"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "build": "fable-splitter tests -o dist/tests --commonjs",
     "pretest": "fable-splitter tests -o dist/tests --commonjs",
     "test": "mocha dist/tests --timeout 5000",
+    "dotnet-test": "dotnet run -p ./tests/Tests.fsproj -- --summary",
     "publish": "fable build.fsx --run clean build test publish",
     "start": "webpack-dev-server",
     "build-for-browser": "webpack"

--- a/src/Mocha.fs
+++ b/src/Mocha.fs
@@ -11,7 +11,7 @@ type FocusState =
 
 type TestCase =
     | SyncTest of string * (unit -> unit) * FocusState
-    | AsyncTest of string * (unit -> Async<unit>) * FocusState
+    | AsyncTest of string * (Async<unit>) * FocusState
     | TestList of string * TestCase list
 
 [<AutoOpen>]
@@ -33,23 +33,23 @@ module private Env =
 
 [<RequireQualifiedAccess>]
 module Expect =
-    let areEqual expected actual : unit =
-        Assert.AreEqual(expected, actual)
-
-    let notEqual expected actual : unit =
-        Assert.NotEqual(expected, actual)
-
-    let areEqualWithMsg expected actual msg : unit =
+    let equal actual expected msg  : unit =
         Assert.AreEqual(expected, actual, msg)
 
-    let notEqualWithMsg expected actual msg : unit =
+    let notEqual actual expected msg  : unit =
         Assert.NotEqual(expected, actual, msg)
 
-    let isTrue cond = areEqual cond true
-    let isFalse cond = areEqual cond false
-    let isZero number = areEqual 0 number
-    let isEmpty (x: 'a seq) = areEqual true (Seq.isEmpty x)
-    let pass() = areEqual true true
+    // let areEqualWithMsg expected actual msg : unit =
+    //     Assert.AreEqual(expected, actual, msg)
+
+    // let notEqualWithMsg expected actual msg : unit =
+    //     Assert.NotEqual(expected, actual, msg)
+
+    let isTrue cond = equal cond true
+    let isFalse cond = equal cond false
+    let isZero number = equal 0 number
+    let isEmpty (x: 'a seq) = equal true (Seq.isEmpty x)
+    let pass() = equal true true
 
 
 
@@ -133,7 +133,7 @@ module Mocha =
         let id = Guid.NewGuid().ToString()
         async {
             do! Async.Sleep 1000
-            match! Async.Catch(test()) with
+            match! Async.Catch(test) with
             | Choice1Of2 () ->
                 let div = Html.findElement id
                 Html.setInnerHtml (sprintf "✔ %s" name) div
@@ -200,7 +200,7 @@ module Mocha =
     let private configureAsyncTest test =
         (fun finished ->
             async {
-                match! Async.Catch(test()) with
+                match! Async.Catch(test) with
                 | Choice1Of2 () -> do finished()
                 | Choice2Of2 err -> do finished(unbox err)
             } |> Async.StartImmediate )

--- a/src/Mocha.fs
+++ b/src/Mocha.fs
@@ -39,12 +39,6 @@ module Expect =
     let notEqual actual expected msg  : unit =
         Assert.NotEqual(expected, actual, msg)
 
-    // let areEqualWithMsg expected actual msg : unit =
-    //     Assert.AreEqual(expected, actual, msg)
-
-    // let notEqualWithMsg expected actual msg : unit =
-    //     Assert.NotEqual(expected, actual, msg)
-
     let isTrue cond = equal cond true
     let isFalse cond = equal cond false
     let isZero number = equal 0 number

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -1,31 +1,36 @@
 module Tests
 
+
+#if FABLE_COMPILER
 open Fable.Mocha
+#else
+open Expecto
+#endif
 
 let mochaTests =
     testList "Mocha framework tests" [
 
         testCase "testCase works" <| fun () ->
-            Expect.areEqual (1 + 1) 2
+            Expect.equal 2 (1 + 1) "Should be equal"
 
         testCase "isFalse works" <| fun () ->
-            Expect.isFalse (1 = 2)
+            Expect.isFalse (1 = 2) "Should be equal"
 
         testCase "areEqual with msg" <| fun _ ->
-            Expect.areEqualWithMsg  1 1 "They are the same"
+            Expect.equal  1 1 "They are the same"
 
-        testCaseAsync "testCaseAsync works" <| fun () ->
+        testCaseAsync "testCaseAsync works" <|
             async {
                 do! Async.Sleep 1000
                 let! x = async { return 21 }
                 let answer = x * 2
-                Expect.areEqual 42 answer
+                Expect.equal 42 answer "Should be equal"
             }
 
         ptestCase "skipping this one" <| fun _ ->
             failwith "Shouldn't be running this test"
 
-        ptestCaseAsync "skipping this one async" <| fun _ ->
+        ptestCaseAsync "skipping this one async" <| 
             async {
                 failwith "Shouldn't be running this test"
             }
@@ -36,7 +41,7 @@ let secondModuleTests =
         testCase "module works properly" <| fun _ ->
             let answer = 31415.0
             let pi = answer / 10000.0
-            Expect.areEqual 3.1415 pi
+            Expect.equal 3.1415 pi "Should be equal"
     ]
 
 let structuralEqualityTests =
@@ -44,35 +49,44 @@ let structuralEqualityTests =
         testCase "they are equal" <| fun _ ->
             let expected = {| one = "one"; two = 2 |}
             let actual = {| one = "one"; two = 2 |}
-            Expect.areEqual expected actual
+            Expect.equal expected actual "Should be equal"
 
         testCase "they are not equal" <| fun _ ->
             let expected = {| one = "one"; two = 1 |}
             let actual = {| one = "one"; two = 2 |}
-            Expect.notEqual expected actual
+            Expect.notEqual expected actual "Should be equal"
     ]
 
 let nestedTestCase =
     testList "Nested" [
         testList "Nested even more" [
-            testCase "Nested test case" <| fun _ -> Expect.isTrue true
+            testCase "Nested test case" <| fun _ -> Expect.isTrue true "Should be true"
         ]
     ]
 
 let focusedTestsCases =
     testList "Focused" [
         ftestCase "Focused sync test" <| fun _ ->
-            Expect.areEqual (1 + 1) 2
-        ftestCaseAsync "Focused async test" <| fun _ ->
+            Expect.equal (1 + 1) 2 "Should be equal"
+        ftestCaseAsync "Focused async test" <|
             async {
-                Expect.areEqual (1 + 1) 2
+                Expect.equal (1 + 1) 2 "Should be equal"
             }
     ]
 
-Mocha.runTests [
+let allTests = [
     mochaTests
     secondModuleTests
     structuralEqualityTests
     nestedTestCase
     // focusedTestsCases
 ]
+
+#if FABLE_COMPILER
+Mocha.runTests allTests
+#else
+[<EntryPoint>]
+let main args =
+    testList "All" allTests
+    |> runTestsWithArgs defaultConfig args
+#endif

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -1,10 +1,11 @@
 module Tests
 
 
-#if FABLE_COMPILER
-open Fable.Mocha
-#else
+
+#if EXPECTO
 open Expecto
+#else 
+open Fable.Mocha
 #endif
 
 let mochaTests =
@@ -74,7 +75,7 @@ let focusedTestsCases =
             }
     ]
 
-let allTests = [
+let allTests = testList "All" [
     mochaTests
     secondModuleTests
     structuralEqualityTests
@@ -84,11 +85,8 @@ let allTests = [
 
 [<EntryPoint>]
 let main args =
-
-#if FABLE_COMPILER
-    Mocha.runTests allTests
-    0
+#if EXPECTO
+    runTestsWithArgs defaultConfig args allTests
 #else
-    testList "All" allTests
-    |> runTestsWithArgs defaultConfig args
+    Mocha.runTests allTests
 #endif

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -82,11 +82,13 @@ let allTests = [
     // focusedTestsCases
 ]
 
-#if FABLE_COMPILER
-Mocha.runTests allTests
-#else
 [<EntryPoint>]
 let main args =
+
+#if FABLE_COMPILER
+    Mocha.runTests allTests
+    0
+#else
     testList "All" allTests
     |> runTestsWithArgs defaultConfig args
 #endif

--- a/tests/Tests.fsproj
+++ b/tests/Tests.fsproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <OutputType>exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Tests.fs" />
@@ -11,6 +12,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="expecto" Version="8.10.1" />
     <PackageReference Include="Fable.Core" Version="3.0.0" />
     <PackageReference Include="Fable.SimpleJson" Version="3.0.0" />
   </ItemGroup>

--- a/tests/Tests.fsproj
+++ b/tests/Tests.fsproj
@@ -6,11 +6,12 @@
   <ItemGroup>
     <Compile Include="Tests.fs" />
   </ItemGroup>
-
+  <PropertyGroup Condition="'$(Configuration)'=='EXPECTO'">
+    <DefineConstants>$(DefineConstants);EXPECTO</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Fable.Mocha.fsproj" />
   </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="expecto" Version="8.10.1" />
     <PackageReference Include="Fable.Core" Version="3.0.0" />


### PR DESCRIPTION
Part one of #5.  Thi aligns the `Expect` functions and `testCase` functions to be in line with Expecto.  

This also adds running the tests via Expecto using a `Configuration` settings and defining an `EXPECTO` Constant and using it as compiler directive.  Now the tests can be run via node, webpack, or expecto.  This does not implement a dotnet runner yet.