### PR TITLE
Fix arguments order of Expect.equal

### DIFF
--- a/src/Mocha.fs
+++ b/src/Mocha.fs
@@ -41,7 +41,7 @@ module Env =
 
 [<RequireQualifiedAccess>]
 module Expect =
-    let inline equal (expected: 'a) (actual: 'a)  msg  : unit =
+    let inline equal (actual: 'a) (expected: 'a) msg  : unit =
         if actual = expected || not (Env.isBrowser()) then
             Assert.AreEqual(actual, expected, msg)
         else

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -32,13 +32,13 @@ let mochaTests =
         ]
 
         testCase "testCase works with numbers" <| fun () ->
-            Expect.equal 2 (1 + 1) "Should be equal Should be equal Should be equal Should be equal Should be equal Should be equal Should be equal Should be equal"
+            Expect.equal (1 + 1) 2 "Should be equal Should be equal Should be equal Should be equal Should be equal Should be equal Should be equal Should be equal"
 
         testCase "isFalse works" <| fun () ->
             Expect.isFalse (1 = 2) "Should be equal"
 
         testCase "areEqual with msg" <| fun _ ->
-            Expect.equal  2 2 "They are the same"
+            Expect.equal 2 2 "They are the same"
 
         testCase "isOk works correctly" <| fun _ ->
             let actual = Ok true
@@ -57,7 +57,7 @@ let mochaTests =
                 do! Async.Sleep 3000
                 let! x = async { return 21 }
                 let answer = x * 2
-                Expect.equal 42 answer "Should be equal"
+                Expect.equal answer 42 "Should be equal"
             }
 
         ptestCase "skipping this one" <| fun _ ->
@@ -74,7 +74,7 @@ let secondModuleTests =
         testCase "module works properly" <| fun _ ->
             let answer = 31415.0
             let pi = answer / 10000.0
-            Expect.equal 3.1415 pi "Should be equal"
+            Expect.equal pi 3.1415 "Should be equal"
     ]
 
 let structuralEqualityTests =
@@ -82,12 +82,12 @@ let structuralEqualityTests =
         testCase "they are equal" <| fun _ ->
             let expected = {| one = "one"; two = 2 |}
             let actual = {| one = "one"; two = 2 |}
-            Expect.equal expected actual "Should be equal"
+            Expect.equal actual expected "Should be equal"
 
         testCase "they are not equal" <| fun _ ->
             let expected = {| one = "one"; two = 1 |}
             let actual = {| one = "one"; two = 2 |}
-            Expect.notEqual expected actual "Should be equal"
+            Expect.notEqual actual expected "Should be equal"
     ]
 
 let nestedTestCase =


### PR DESCRIPTION
Hello,
here are the results of the change when running in the different env

**Test**
![image](https://user-images.githubusercontent.com/4760796/82680558-bb2da600-9c4c-11ea-8fe4-e44ca92af3a3.png)

**Node.js env**
![image](https://user-images.githubusercontent.com/4760796/82680550-b832b580-9c4c-11ea-98a1-e7267d7688a0.png)

**Browser env**
![image](https://user-images.githubusercontent.com/4760796/82680500-a3eeb880-9c4c-11ea-9a0a-4120a58e43f3.png)

**Headless env**
![image](https://user-images.githubusercontent.com/4760796/82680743-0051d800-9c4d-11ea-9d06-311016bdc336.png)

**Expecto env**
![image](https://user-images.githubusercontent.com/4760796/82681373-f8defe80-9c4d-11ea-9106-34aa6424e7f6.png)
