### PR TITLE
add stringContains to Expect module

### DIFF
--- a/src/Mocha.fs
+++ b/src/Mocha.fs
@@ -67,6 +67,10 @@ module Expect =
         match x with
         | Ok _ -> pass() message
         | Error x' -> failwithf "%s. Expected Ok, was Error(%A)." message x'
+    let stringContains (subject: string) (substring: string) message =
+        if not (subject.Contains(substring)) 
+        then failwithf "%s. Expected subject string '%s' to contain substring '%s'." message subject substring
+        else pass() message
 
 module private Html =
     type Node = {

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -67,6 +67,22 @@ let mochaTests =
             async {
                 failwith "Shouldn't be running this test"
             }
+
+        testCase "stringContains works correctly" <| fun _ ->
+            let actual = Ok true
+            Expect.stringContains "Hello, World!" "World" "Should contain string"
+
+        testCase "stringContains fails correctly" <| fun _ ->
+            let actual = Error "fails"
+            try
+                Expect.stringContains "Hello, Mocha!" "World" "Should fail"
+                Expect.equal true false "Should not be tested"
+            with
+            | ex -> 
+                Expect.equal 
+                    ex.Message 
+                    "Should fail. Expected subject string 'Hello, Mocha!' to contain substring 'World'." 
+                    "Error messages should be the same"
     ]
 
 let secondModuleTests =


### PR DESCRIPTION
Copied the implementation of `Expect.stringContains` from expecto. 

We need this in fsharp.hedgehog. See [Fix for counterexample crashing bug #327](https://github.com/hedgehogqa/fsharp-hedgehog/pull/328).