### PR TITLE
Fixed broken isNonEmpty

### DIFF
--- a/src/Mocha.fs
+++ b/src/Mocha.fs
@@ -69,12 +69,13 @@ module Expect =
     let isTrue cond = equal cond true
     let isFalse cond = equal cond false
     let isZero cond = equal cond 0
-    let isEmpty (x: 'a seq) msg = if not (Seq.isEmpty x) then failwith msg
+    let isEmpty (x: 'a seq) msg = if not (Seq.isEmpty x) then failwithf "%s. Should be empty." msg
     let pass() = equal true true "The test passed"
     let passWithMsg (message: string) = equal true true message
     let exists (x: 'a seq) (a: 'a -> bool) msg = if not (Seq.exists a x) then failwith msg
     let all (x: 'a seq) (a: 'a -> bool) msg = if not (Seq.forall a x) then failwith msg
-    let isNonEmpty (x: 'a seq) msg = if not (Seq.isEmpty x) then failwithf "%s. Expected seq to be empty" msg
+    /// Expect the passed sequence not to be empty.
+    let isNonEmpty (x: 'a seq) msg = if Seq.isEmpty x then failwithf "%s. Should not be empty." msg
     /// Expects x to be not null nor empty
     let isNotEmpty (x: 'a seq) msg =
         isNotNull x msg

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -52,6 +52,32 @@ let mochaTests =
             let catch (exn: System.Exception) =
                 Expect.equal exn.Message "Should fail. Expected Ok, was Error(\"fails\")." "Error messages should be the same"
             Expect.throwsC case catch
+
+        testCase "isEmpty works correctly" <| fun _ ->
+            let actual = []
+            Expect.isEmpty actual "Should be empty"
+
+        testCase "isEmpty fails correctly" <| fun _ ->
+            let case () =
+                let actual = [1]
+                Expect.isEmpty actual "Should fail"
+                Expect.equal true false "Should not be tested"
+            let catch (exn: System.Exception) =
+                Expect.equal exn.Message "Should fail. Should be empty." "Error messages should be the same"
+            Expect.throwsC case catch
+
+        testCase "isNonEmpty works correctly" <| fun _ ->
+            let actual = [1]
+            Expect.isNonEmpty actual "Should not be empty"
+
+        testCase "isNonEmpty fails correctly" <| fun _ ->
+            let case () =
+                let actual = []
+                Expect.isNonEmpty actual "Should fail"
+                Expect.equal true false "Should not be tested"
+            let catch (exn: System.Exception) =
+                Expect.equal exn.Message "Should fail. Should not be empty." "Error messages should be the same"
+            Expect.throwsC case catch
         
         testCase "isError works correctly" <| fun _ ->
             let actual = Error "Is Error"


### PR DESCRIPTION
`isNonEmpty` is currently doing the same check as `isEmpty`, which is obviously broken.
Added a test to make sure `isEmtpy` and `isNonEmpty` work as intended.